### PR TITLE
refactor how we handle tradingData to allow getData to return routes

### DIFF
--- a/TradeBeacons/data/scripts/entity/tradebeacon.lua
+++ b/TradeBeacons/data/scripts/entity/tradebeacon.lua
@@ -88,7 +88,7 @@ function TradeBeacon.registerWithPlayer()
     local tradeData = TradeBeacon.getTradeData()
     local script = "tradebeacon.lua"
     for _, player in pairs(TradeBeacon.getPlayersToNotify()) do
-        player:invokeFunction(script, "registerTradeBeacon", x, y, entityId, tradeData, burnOutTime)
+        invokeRemoteFactionFunction(player.index, script, "registerTradeBeacon", x, y, entityId, tradeData, burnOutTime)
     end
     didSendInfoOnce = true
 end
@@ -97,7 +97,7 @@ function TradeBeacon.unregisterWithPlayer()
     local entityId = Entity().index.string
     local script = "tradebeacon.lua"
     for _, player in pairs(TradeBeacon.getPlayersToNotify()) do
-        player:invokeFunction(script, "deregisterTradeBeacon", entityId)
+        invokeRemoteFactionFunction(player.index, script, "deregisterTradeBeacon", entityId)
     end
 end
 
@@ -140,7 +140,7 @@ function TradeBeacon.updateServerCharged()
     TradeBeacon.registerWithPlayer()
 
     if traderAffinity ~= nil and traderAffinity > 0 and random():getFloat() < traderAffinity then
-        Sector():addScriptOnce("data/scripts/player/spawntravellingmerchant.lua")
+        Sector():addScriptOnce("data/scripts/player/events/spawntravellingmerchant.lua")
     end
 end
 

--- a/TradeBeacons/data/scripts/systems/tradingoverview.lua
+++ b/TradeBeacons/data/scripts/systems/tradingoverview.lua
@@ -142,7 +142,7 @@ function requestSectorsData(caller)
     local x, y = Sector():getCoordinates()
     local script = "tradebeacon.lua"
 
-    player:invokeFunction(script, "requestSectorsData", x, y, historySize, entityId, caller)
+    invokeRemoteFactionFunction(player.index, script, "requestSectorsData", x, y, historySize, entityId, caller)
 end
 
 function receiveTradingInfoFromPlayer(caller, sectorsDataString)

--- a/TradeBeacons/modinfo.lua
+++ b/TradeBeacons/modinfo.lua
@@ -42,7 +42,7 @@ meta =
         {id = "1841868691", min = "1.0", optional = true},
         {id = "1722652757", min = "1.3.5"},
         {id = "1837703287", min = "1.1"},
-        {id = "Avorion", min = "0.25", max = "0.26.1"}
+        {id = "Avorion", min = "0.25", max = "0.27"}
     },
 
     -- Set to true if the mod only has to run on the server. Clients will get notified that the mod is running on the server, but they won't download it to themselves


### PR DESCRIPTION
core goal here is that the client experience should remain unchanged
but server scripts can get routes from the trading system